### PR TITLE
Support reset, virtual and recurring options

### DIFF
--- a/src/Tribe/Cli.php
+++ b/src/Tribe/Cli.php
@@ -34,5 +34,6 @@ class Cli extends \tad_DI52_ServiceProvider {
 		\WP_CLI::add_command( 'tec-test-data venues generate', [ $command, 'generate_venues' ] );
 		\WP_CLI::add_command( 'tec-test-data image generate', [ $command, 'generate_images' ] );
 		\WP_CLI::add_command( 'tec-test-data delete', [ $command, 'delete' ] );
+		\WP_CLI::add_command( 'tec-test-data reset', [ $command, 'reset' ] );
 	}
 }

--- a/src/Tribe/Generator/Organizer.php
+++ b/src/Tribe/Generator/Organizer.php
@@ -5,18 +5,31 @@ use Faker\Factory;
 
 class Organizer {
 	/**
-	 * Creates randomly generated Organizers
+	 * Creates randomly generated Organizers.
 	 *
 	 * @since 1.0.0
-	 * @param int $quantity
-	 * @param array $args
-	 * @return mixed
-	 * @throws \Tribe__Repository__Usage_Error
+	 * @since TBD Added support for the `$tick` parameter.
+	 *
+	 * @param int                           $quantity The number of Organizers to create.
+	 * @param array<string,string|int|bool> $args     An array of arguments to customize the Organizer creation.
+	 * @param callable|null                 $tick     An optional callback that will be fired after each Organizer creation;
+	 *                                                the callback will receive the just created Organizer post object as
+	 *                                                argument.
+	 *
+	 * @throws \Tribe__Repository__Usage_Error If the arguments do not make sense in the context of the ORM Organizer
+	 *                                         creation.
+	 *
+	 * @return array<\WP_Post> An array of the generated Organizers post objects.
 	 */
-	public function create( $quantity = 1, array $args = [] ) {
+	public function create( $quantity = 1, array $args = [], callable $tick = null ) {
 		for ( $i = 1; $i <= $quantity; $i++ ) {
 			$organizers[] = tribe_organizers()->set_args( $this->random_organizer_data() )->create();
+
+			if ( is_callable( $tick ) ) {
+				$tick( end( $organizers ) );
+			}
 		}
+
 		return $organizers;
 	}
 

--- a/src/Tribe/Generator/Utils.php
+++ b/src/Tribe/Generator/Utils.php
@@ -1,24 +1,32 @@
 <?php
 namespace Tribe\Extensions\Test_Data_Generator\Generator;
 
-use Exception;
-use Faker\Factory;
-
 class Utils {
 
 	/**
 	 * Upload random images into Media Gallery
 	 *
 	 * @since 1.0.0
-	 * @param int $quantity
-	 * @param array $args
-	 * @return mixed
+	 * @since TBD Added support for the `$tick` parameter.
+	 *
+	 * @param int                           $quantity The number of images to import to the site.
+	 * @param array<string,string|int|bool> $args     The upload arguments.
+	 * @param callable|null                 $tick     An optional callback that will be fired after each Image upload;
+	 *                                                the callback will receive the just uploaded image post ID as
+	 *                                                argument.
+	 *
+	 * @return array<int|bool> An array of attachment post IDs or `false` if the upload failed.
 	 */
-	public function upload( $quantity = 1, array $args = [] ) {
+	public function upload( $quantity = 1, array $args = [], callable $tick = null ) {
 		for ( $i = 0; $i < $quantity; $i++ ) {
 			$image_url = 'https://picsum.photos/640/360' . '#' . bin2hex(random_bytes(16));
 			$uploads[] = tribe_upload_image($image_url);
 		}
+
+		if ( is_callable( $tick ) ) {
+			$tick( end( $uploads ) );
+		}
+
 		return $uploads;
 	}
 
@@ -41,6 +49,10 @@ class Utils {
 				tribe_events()->by( 'meta_like', 'tribe_test_data_gen' )->delete();
 			}
 		}
+
+		// There's a number of things that might need updates after such a reset.
+		wp_cache_flush();
+
 		return true;
 	}
 
@@ -63,6 +75,10 @@ class Utils {
 				tribe_events()->delete();
 			}
 		}
+
+		// There's a number of things that might need updates after such a reset.
+		wp_cache_flush();
+
 		return true;
 	}
 
@@ -115,6 +131,9 @@ class Utils {
 	            delete_transient( $transient );
             }
         }
+
+	    // There's a number of things that might need updates after such a reset.
+	    wp_cache_flush();
 
 	    return true;
     }

--- a/src/Tribe/Generator/Venue.php
+++ b/src/Tribe/Generator/Venue.php
@@ -5,18 +5,31 @@ use Faker\Factory;
 
 class Venue {
 	/**
-	 * Creates randomly generated Venues
+	 * Creates randomly generated Venues.
 	 *
 	 * @since 1.0.0
-	 * @param int $quantity
-	 * @param array $args
-	 * @return mixed
-	 * @throws \Tribe__Repository__Usage_Error
+	 * @since TBD Added support for the `$tick` parameter.
+ *
+	 * @param int                           $quantity The number of Venues to create.
+	 * @param array<string,string|int|bool> $args     An array of arguments to customize the Venue creation.
+	 * @param callable|null                 $tick     An optional callback that will be fired after each Venue creation;
+	 *                                                the callback will receive the just created Venue post object as
+	 *                                                argument.
+	 *
+	 * @return array<\WP_Post> An array of the generated Venues post objects.
+	 *@throws \Tribe__Repository__Usage_Error If the arguments do not make sense in the context of the ORM Venue
+	 *                                         creation.
+	 *
 	 */
-	public function create( $quantity = 1, array $args = [] ) {
+	public function create( $quantity = 1, array $args = [], callable  $tick = null ) {
 		for ( $i = 1; $i <= $quantity; $i++ ) {
 			$venues[] = tribe_venues()->set_args( $this->random_venue_data() )->create();
+
+			if ( is_callable( $tick ) ) {
+				$tick( end( $venues ) );
+			}
 		}
+
 		return $venues;
 	}
 


### PR DESCRIPTION
This PR:

1. Adds a `wp tec-test-data reset` command to allow resetting our transients and options from wp-cli.
2. Adds support for the `--virtual` flag when generating events to generate Virtual Events.
3. Adds support for the `--recurring=[<type>]` flag when generatin events to allow creating recurring events with the speicified recurrence pattern. If not specified, then the `all` pattern will be used and a random recurrence pattern will be picked for each event.
4. Refactors and clean up the wp-cli related and other code a bit.
5. Adds support, in each generator, for a "tick" callback to do something after each image has been uploaded or each event, venue or organizer has been generated.
6. Adds progress bars to each generators to provide more observability to the wp-cli based generation process.

[Screencap](https://drive.google.com/open?id=1BL_VBBNfQCEE2ijgpy-RXmjus0FG06YV&authuser=luca%40tri.be&usp=drive_fs)