### PR TITLE
Fix duration, support fast insert

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -4,9 +4,9 @@
  * Plugin URI:
  * GitHub Plugin URI: https://github.com/mt-support/tribe-ext-test-data-generator
  * Description:       This extension aims to provide an automated tool to generate high quality, life-like data for The Events Calendar family of plugins.
- * Version:           1.0.5
- * Author:            Modern Tribe, Inc.
- * Author URI:        http://m.tri.be/1971
+ * Version:           1.0.6
+ * Author:            The Events Calendar
+ * Author URI:        http://evnt.is/1971
  * License:           GPL version 3 or any later version
  * License URI:       https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain:       test-data-generator

--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,11 @@
 === The Events Calendar Extension: Test Data Generator ===
 Contributors: ModernTribe, aguseo, bordoni, Camwyn, lirianojoel, lucatume
-Donate link: http://m.tri.be/29
+Donate link: http://evnt.is/29
 Tags: events, calendar
 Requires at least: 4.9.14
-Tested up to: 5.4.2
-Requires PHP: 5.6
-Stable tag: 1.0.5
+Tested up to: 6.0
+Requires PHP: 7.1
+Stable tag: 1.0.6
 License: GPL version 3 or any later version
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -32,6 +32,10 @@ Please visit our [extension library](https://theeventscalendar.com/extensions/) 
 Please create a GitHub issue inside the project.
 
 == Changelog ==
+
+= [1.0.6] 2022-06-01 =
+
+* Enhancement - Add support for Tickets Menu.
 
 = [1.0.5] 2020-10-29 =
 

--- a/src/Tribe/Cli/Command.php
+++ b/src/Tribe/Cli/Command.php
@@ -31,12 +31,13 @@ class Command {
 	 * @var array<string,string>
 	 */
 	protected $events_generator_translation_map = [
-		'from-date'    => 'fromDate',
-		'to-date'      => 'toDate',
-		'with-rsvp'    => 'rsvp',
-		'with-tickets' => 'tickets',
-		'virtual'      => 'virtual',
-		'recurring'    => [ 'recurring', 'recurring_type' ]
+		'from-date'               => 'fromDate',
+		'to-date'                 => 'toDate',
+		'with-rsvp'               => 'rsvp',
+		'with-tickets'            => 'tickets',
+		'virtual'                 => 'virtual',
+		'recurring'               => [ 'recurring', 'recurring_type' ],
+		'fast-occurrences-insert' => 'fastOccurrencesInsert',
 	];
 
 	/**
@@ -111,6 +112,10 @@ class Command {
 	 *   - weekly
 	 *   - daily
 	 * ---
+	 *
+	 * [--fast-occurrences-insert]
+	 * : Whether to insert recurring Events occurrences as fast as possible or not. If this flag is set, then
+	 * recurring Events' occurrences will be inserted with a direct database query, skipping the WordPress hooks.
 	 *
 	 * ## EXAMPLES
 	 *

--- a/src/Tribe/Generator/Event.php
+++ b/src/Tribe/Generator/Event.php
@@ -405,9 +405,10 @@ class Event {
 	 * @return string
 	 */
 	public function determine_timezone( $venue_id ) {
-		$venue_state = get_post_meta( $venue_id, '_VenueState' )[0];
-		$timezone = 'America/New_York';
-		switch( $venue_state ) {
+		$venue_state = get_post_meta( $venue_id, '_VenueState' );
+		$venue       = isset( $venue_state[0] ) ? $venue_state[0] : null;
+		$timezone    = 'America/New_York';
+		switch ( $venue ) {
 			case 'California':
 				$timezone = 'America/Los_Angeles';
 				break;
@@ -415,6 +416,7 @@ class Event {
 				$timezone = 'America/Chicago';
 				break;
 		}
+
 		return $timezone;
 	}
 
@@ -454,13 +456,13 @@ class Event {
 	 * @return string
 	 */
 	public function generate_event_description( $event_title, $organizer_id, $venue_id ) {
-		$faker = Factory::create();
-		$venue = tribe_venues()->by( 'ID', $venue_id )->first();
-		$venue_name = empty( $venue ) ? 'The Venue' : $venue->post_title;
-		$venue_meta_city = get_post_meta( $venue_id )['_VenueCity'][0];
-		$venue_city = empty( $venue_meta_city ) ? 'your city' : $venue_meta_city;
-		$organizer = tribe_organizers()->by( 'ID', $organizer_id )->first();
-		$organizer_name = empty( $organizer ) ? 'a Premium Organizer' : $organizer->post_title;
+		$faker           = Factory::create();
+		$venue           = tribe_venues()->by( 'ID', $venue_id )->first();
+		$venue_name      = empty( $venue ) ? 'The Venue' : $venue->post_title;
+		$venue_meta_city = get_post_meta( $venue_id ) ? get_post_meta( $venue_id )['_VenueCity'][0] : '';
+		$venue_city      = empty( $venue_meta_city ) ? 'your city' : $venue_meta_city;
+		$organizer       = tribe_organizers()->by( 'ID', $organizer_id )->first();
+		$organizer_name  = empty( $organizer ) ? 'a Premium Organizer' : $organizer->post_title;
 		gc_collect_cycles();
 
 		$description =

--- a/src/Tribe/Generator/Event.php
+++ b/src/Tribe/Generator/Event.php
@@ -36,9 +36,9 @@ class Event {
 		$is_recurring   = ! empty( $args['recurring'] );
 		$recurring_type = empty( $args['recurring_type'] ) ? 'all' : $args['recurring_type'];
 		$has_category   = ! empty( $args['add_custom_category'] ) && ! empty( $args['custom_category'] );
-		$event_category = $args['custom_category'];
+		$event_category = isset( $args['custom_category'] ) ? $args['custom_category'] : null;
 		$has_tag        = ! empty( $args['add_custom_tag'] ) && ! empty( $args['custom_tag'] );
-		$event_tag      = $args['custom_tag'];
+		$event_tag      = isset( $args['custom_tag'] ) ? $args['custom_tag'] : null;
 
 		$events         = [];
 

--- a/src/Tribe/Page.php
+++ b/src/Tribe/Page.php
@@ -84,7 +84,17 @@ class Page {
 	 * @since 1.0.0
 	 */
 	public function add_menu() {
-		$parent = class_exists( 'Tribe__Events__Main' ) ? Tribe__Settings::$parent_page : Tribe__Settings::$parent_slug;
+		if ( class_exists( 'Tribe__Events__Main' ) ) {
+			$parent = add_query_arg(
+				[
+					'post_type' => \Tribe__Events__Main::POSTTYPE,
+				],
+				Tribe__Settings::$parent_page
+			);
+		} elseif ( class_exists( 'Tribe__Tickets__Main' ) ) {
+			$parent = \Tribe\Tickets\Admin\Settings::$parent_slug;
+		}
+
 		$this->menu_hook = add_submenu_page(
 			$parent,
 			__( 'Test Data Generator', 'tribe-ext-test-data-generator' ),

--- a/src/Tribe/Plugin_Register.php
+++ b/src/Tribe/Plugin_Register.php
@@ -26,7 +26,7 @@ class Plugin_Register extends Abstract_Plugin_Register {
 	protected $main_class   = Plugin::class;
 	protected $dependencies = [
 		'parent-dependencies' => [
-			'Tribe__Events__Main' => '5.1.0-dev',
+			'Tribe__Events__Main' => '5.15.0-dev',
 		],
 	];
 }


### PR DESCRIPTION
This PR adds support for the `-fast-occurrences-insert` argument to
directly insert Occurrences (in the context of the Legacy engine) using
direct database queries.

Furthermore, this commit ensures the `_EventDuration` meta is correctly
set when creating events to make sure Events crossing the
daylight-saving time and date will have their duration correctly set.
