### PR TITLE
Fix undefined index issue

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,10 @@ Please create a GitHub issue inside the project.
 
 == Changelog ==
 
+= [1.0.8] 2022-06-29 =
+
+* Fix - An undefined index error was occurring when generating events.
+
 = [1.0.7] 2022-06-24 =
 
 * Fix - Ensure `_EventDuration` meta of generated Events is set to the correct value.

--- a/src/Tribe/Generator/Event.php
+++ b/src/Tribe/Generator/Event.php
@@ -77,8 +77,9 @@ class Event {
 					 */
 					$timezone = Timezones::build_timezone_object( $event_payload['timezone']
 					                                              ?? get_option( 'timezone_string' ) );
-					$real_duration = Dates::immutable( $event_payload['to_date'], $timezone )->getTimestamp()
-					                 - Dates::immutable( $event_payload['from_date'], $timezone )->getTimestamp();
+				$real_duration = Dates::immutable( $event_payload['end_date'], $timezone )->getTimestamp()
+
+					                 - Dates::immutable( $event_payload['start_date'], $timezone )->getTimestamp();
 					update_post_meta( $event_post->ID, '_EventDuration', $real_duration );
 				}
 


### PR DESCRIPTION
Fix and undefined index issue that would throw a notice, thus a fatal when `WP_DEBUG` is active,
introduced in version `1.0.7`.

