### PR TITLE
Support multiple category and tag names in wp-cli

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,16 @@ Please create a GitHub issue inside the project.
 
 == Changelog ==
 
+
+= [TBD] TBD =
+
+* Enhancement - Support comma-separated list of category and tag names in wp-cli.
+* Enhancement - Gracefully handle pre-existing category and tag names.
+
+= [1.0.8] 2022-06-29 =
+
+* Fix - An undefined index error was occurring when generating events.
+
 = [1.0.7] 2022-06-24 =
 
 * Fix - Ensure `_EventDuration` meta of generated Events is set to the correct value.

--- a/src/Tribe/Cli/Command.php
+++ b/src/Tribe/Cli/Command.php
@@ -38,6 +38,8 @@ class Command {
 		'virtual'                 => 'virtual',
 		'recurring'               => [ 'recurring', 'recurring_type' ],
 		'fast-occurrences-insert' => 'fastOccurrencesInsert',
+		'category'                => 'event_category',
+		'tag'                     => 'event_tag',
 	];
 
 	/**
@@ -113,6 +115,12 @@ class Command {
 	 *   - daily
 	 * ---
 	 *
+	 * [--category=<category>]
+	 * : A comma-separated list of categories to assign to the generated Events.
+	 *
+	 * [--tag=<tag>]
+	 * : A comma-separated list of tags to assign to the generated Events.
+	 *
 	 * [--fast-occurrences-insert]
 	 * : Whether to insert recurring Events occurrences as fast as possible or not. If this flag is set, then
 	 * recurring Events' occurrences will be inserted with a direct database query, skipping the WordPress hooks.
@@ -130,6 +138,10 @@ class Command {
 	 *     wp tec-test-data events generate 23 --recurring
 	 *     wp tec-test-data events generate 23 --recurring=all
 	 *     wp tec-test-data events generate 23 --recurring=weekly
+	 *     wp tec-test-data events generate 23 --category=party
+	 *     wp tec-test-data events generate 23 --category=party,concert
+	 *     wp tec-test-data events generate 23 --tag=fun
+	 *     wp tec-test-data events generate 23 --tag=fun,hiking
 	 *
 	 * @when after_wp_load
 	 */

--- a/src/Tribe/Generator/Event.php
+++ b/src/Tribe/Generator/Event.php
@@ -82,7 +82,7 @@ class Event {
 					$timezone = Timezones::build_timezone_object( $event_payload['timezone']
 					                                              ?? get_option( 'timezone_string' ) );
 
-				$real_duration = Dates::immutable( $event_payload['end_date'], $timezone )->getTimestamp()
+					$real_duration = Dates::immutable( $event_payload['end_date'], $timezone )->getTimestamp()
 					                 - Dates::immutable( $event_payload['start_date'], $timezone )->getTimestamp();
 					update_post_meta( $event_post->ID, '_EventDuration', $real_duration );
 				}


### PR DESCRIPTION
Support, in the context of wp-cli, the creation of multiple event category and tag terms using commands like:

```
wp tec-test-data events generate 10 --category=sortie --tag=mountain,hiking --recurring
```

Refactor the code to allow it and clean it up.
